### PR TITLE
Exclude Group Policy Failed Event Code 1006

### DIFF
--- a/latest/windows_builtin/win_defender_threat-edr.yml
+++ b/latest/windows_builtin/win_defender_threat-edr.yml
@@ -21,6 +21,11 @@ detect:
       op: is
       path: event/EVENT/System/EventID
       value: '1117'
+  - not: true
+    op: is
+    case sensitive: false
+    path: event/EVENT/System/Provider/Name
+    value: 'Microsoft-Windows-GroupPolicy'
 respond:
 - action: report
   metadata:


### PR DESCRIPTION
## Description of the change
I would like to exclude the Group Policy provider from generating Lima Charlie Defender Threat Detected events. I'm proposing to just exclude the provider Microsoft-Windows-GroupPolicy instead of filtering on the provider "Microsoft-Windows-Windows Defender". I'm not sure if the defender provider name will change over time.

## Type of change
- [ x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
